### PR TITLE
fix(interpolate): never abort() on non-increasing x in Interpolator1D

### DIFF
--- a/HighMap/include/highmap/interpolate/interpolate1d.hpp
+++ b/HighMap/include/highmap/interpolate/interpolate1d.hpp
@@ -71,13 +71,20 @@ public:
    * This constructor initializes the interpolation object with the provided x
    * and y data points and the specified interpolation method.
    *
-   * @param  x      A vector of x coordinates (independent variable).
+   * Coincident x coordinates are merged (keeping the first y) so that
+   * valid-but-sloppy data still interpolates instead of crashing; GSL's
+   * abort-on-error handler is disabled so a precondition violation throws a
+   * catchable exception rather than terminating the process.
+   *
+   * @param  x      A vector of x coordinates (independent variable). Must be
+   *                sorted in increasing order.
    * @param  y      A vector of y coordinates (dependent variable).
    * @param  method The interpolation method to use (default is linear).
    *
-   * @throws std::invalid_argumentifxandyhavedifferentsizesoriftherearefewerthan
-   *                two points. An exception is also thrown if the method
-   * requires monotonic data and the provided data is not monotonic.
+   * @throws std::invalid_argument if x and y have different sizes, if there
+   *                are fewer than two points with distinct x values, if x is
+   *                not sorted in increasing order, or if the method requires
+   *                monotonic data and the provided data is not monotonic.
    */
   Interpolator1D(const std::vector<float> &x,
                  const std::vector<float> &y,

--- a/HighMap/src/interpolate/interpolate1d.cpp
+++ b/HighMap/src/interpolate/interpolate1d.cpp
@@ -7,6 +7,7 @@
 #include <stdexcept>
 #include <vector>
 
+#include <gsl/gsl_errno.h>
 #include <gsl/gsl_interp.h>
 #include <gsl/gsl_spline.h>
 
@@ -40,6 +41,40 @@ Interpolator1D::Interpolator1D(const std::vector<float> &x,
 
   this->x_data = std::vector<double>(x.begin(), x.end());
   this->y_data = std::vector<double>(y.begin(), y.end());
+
+  // GSL requires strictly increasing x: gsl_spline_init() with coincident or
+  // out-of-order x invokes GSL's default error handler, which abort()s the
+  // whole process (SIGABRT) instead of letting the caller recover. Merge
+  // coincident x (keeping the first y) so valid-but-sloppy data - duplicate
+  // colour-gradient stops, presets, float rounding - still renders, and throw
+  // a catchable exception only when the data cannot be repaired.
+  {
+    std::vector<double> xs, ys;
+    xs.reserve(this->x_data.size());
+    ys.reserve(this->y_data.size());
+
+    for (size_t i = 0; i < this->x_data.size(); ++i)
+    {
+      if (!xs.empty() && this->x_data[i] < xs.back())
+        throw std::invalid_argument(
+            "x values must be sorted in increasing order.");
+
+      if (!xs.empty() && this->x_data[i] == xs.back())
+        continue; // drop coincident point, keep the first y
+
+      xs.push_back(this->x_data[i]);
+      ys.push_back(this->y_data[i]);
+    }
+
+    this->x_data = std::move(xs);
+    this->y_data = std::move(ys);
+  }
+
+  if (this->x_data.size() < 2)
+  {
+    throw std::invalid_argument(
+        "at least two points with distinct x values are required.");
+  }
 
   const size_t size = this->x_data.size();
 
@@ -86,7 +121,24 @@ Interpolator1D::Interpolator1D(const std::vector<float> &x,
   default: throw std::invalid_argument("Unsupported interpolation method.");
   }
 
-  gsl_spline_init(this->interp, this->x_data.data(), this->y_data.data(), size);
+  // Belt-and-braces: never let GSL abort() the host process. Disable the
+  // default (abort-on-error) handler process-wide and turn any residual GSL
+  // error into a catchable exception instead of a SIGABRT.
+  gsl_set_error_handler_off();
+
+  const int status = gsl_spline_init(this->interp,
+                                     this->x_data.data(),
+                                     this->y_data.data(),
+                                     size);
+
+  if (status != GSL_SUCCESS)
+  {
+    gsl_spline_free(this->interp);
+    gsl_interp_accel_free(this->accel_);
+    throw std::invalid_argument(
+        std::string("GSL spline initialization failed: ") +
+        gsl_strerror(status));
+  }
 }
 
 Interpolator1D::~Interpolator1D()

--- a/tests/src/test_interpolate1d.cpp
+++ b/tests/src/test_interpolate1d.cpp
@@ -1,0 +1,55 @@
+#include "highmap.hpp"
+
+#include <gtest/gtest.h>
+
+using namespace hmap;
+
+// Coincident x used to reach gsl_spline_init() and abort() the whole process
+// (gsl: interp.c: "x values must be strictly increasing"). They must now be
+// merged so the interpolator still builds and evaluates.
+TEST(Interpolator1D, CoincidentXDoesNotCrash)
+{
+  std::vector<float> x = {0.f, 0.f, 0.5f, 1.f, 1.f};
+  std::vector<float> y = {0.f, 0.f, 0.5f, 1.f, 1.f};
+
+  EXPECT_NO_THROW({
+    Interpolator1D itp(x, y, InterpolationMethod1D::LINEAR);
+    EXPECT_NEAR(itp(0.f), 0.f, 1e-5f);
+    EXPECT_NEAR(itp(0.5f), 0.5f, 1e-5f);
+    EXPECT_NEAR(itp(1.f), 1.f, 1e-5f);
+  });
+}
+
+// After merging coincident x there must still be at least two distinct points.
+TEST(Interpolator1D, AllCoincidentXThrows)
+{
+  std::vector<float> x = {0.5f, 0.5f, 0.5f};
+  std::vector<float> y = {0.f, 1.f, 2.f};
+
+  EXPECT_THROW(Interpolator1D(x, y, InterpolationMethod1D::LINEAR),
+               std::invalid_argument);
+}
+
+// Out-of-order (decreasing) x is unrepairable and must throw, not abort.
+TEST(Interpolator1D, DecreasingXThrows)
+{
+  std::vector<float> x = {0.f, 1.f, 0.5f};
+  std::vector<float> y = {0.f, 1.f, 0.5f};
+
+  EXPECT_THROW(Interpolator1D(x, y, InterpolationMethod1D::LINEAR),
+               std::invalid_argument);
+}
+
+// Existing preconditions remain enforced.
+TEST(Interpolator1D, MismatchedOrTooFewPointsThrows)
+{
+  EXPECT_THROW(Interpolator1D(std::vector<float>{0.f, 1.f},
+                              std::vector<float>{0.f},
+                              InterpolationMethod1D::LINEAR),
+               std::invalid_argument);
+
+  EXPECT_THROW(Interpolator1D(std::vector<float>{0.f},
+                              std::vector<float>{0.f},
+                              InterpolationMethod1D::LINEAR),
+               std::invalid_argument);
+}


### PR DESCRIPTION
## Problem

`gsl_spline_init()` requires strictly increasing `x`. When the `x` array is not strictly increasing — duplicate colour-gradient stops, presets, the `colorize` `reverse` mapping (`p -> 1 - p`), or plain float rounding — GSL invokes its **default error handler**, which calls `abort()` and kills the entire host process:

```
gsl: interp.c:83: ERROR: x values must be strictly increasing
Default GSL error handler invoked.
IOT instruction (core dumped)
```

This was reproducible from a downstream app by double-clicking a `ColorizeGradient` node's gradient bar near an existing stop, producing two coincident stop positions that flow into `Interpolator1D` via `hmap::colorize`.

## Fix

Make `Interpolator1D` robust instead of letting GSL `abort()`:

- **Merge coincident `x`** (keeping the first `y`) so valid-but-sloppy data still interpolates and renders rather than crashing.
- **Throw the catchable `std::invalid_argument`** (already used for the other preconditions) when `x` is decreasing or fewer than two distinct points remain after merging — so callers can degrade gracefully.
- **Disable GSL's abort-on-error handler** (`gsl_set_error_handler_off`) and check `gsl_spline_init()`'s return code, converting any residual GSL error into an exception. GSL can no longer `abort()` the host.

## Tests

Adds `tests/src/test_interpolate1d.cpp` (auto-globbed by the existing test CMake) covering:
- coincident `x` → merges, builds, and evaluates correctly (the original crash);
- all-coincident `x` → throws;
- decreasing `x` → throws;
- mismatched / too-few inputs → still throw.

The new constructor logic was also verified against real GSL 2.8 in a standalone harness (all cases pass; no `abort()`).