### PR TITLE
feat(noise): add periodic/tileable mode to GPU noise

### DIFF
--- a/HighMap/include/highmap/dbg/assert.hpp
+++ b/HighMap/include/highmap/dbg/assert.hpp
@@ -49,4 +49,7 @@ void print_array(const Array &arr,
                  int          width = 6,
                  int          precision = 2);
 
+void dump_visual_check(const Array       &array,
+                       const std::string &fname = "check.png");
+
 } // namespace hmap

--- a/HighMap/include/highmap/primitives/coherent_noise.hpp
+++ b/HighMap/include/highmap/primitives/coherent_noise.hpp
@@ -806,7 +806,7 @@ Array noise(NoiseType     noise_type,
             const Array  *p_noise_y = nullptr,
             const Array  *p_stretching = nullptr,
             glm::vec4     bbox = {0.f, 1.f, 0.f, 1.f},
-            glm::ivec2    period = {-1, -1});
+            glm::ivec2    period = {0, 0});
 
 /*! @brief See hmap::noise_fbm. @p period sets the tiling period in lattice
  * cells (typically round(kw)); a non-positive component disables wrapping on
@@ -825,7 +825,7 @@ Array noise_fbm(NoiseType     noise_type,
                 const Array  *p_noise_y = nullptr,
                 const Array  *p_stretching = nullptr,
                 glm::vec4     bbox = {0.f, 1.f, 0.f, 1.f},
-                glm::ivec2    period = {-1, -1});
+                glm::ivec2    period = {0, 0});
 
 /**
  * @brief Generates a procedural phasor-based pattern.

--- a/HighMap/include/highmap/primitives/coherent_noise.hpp
+++ b/HighMap/include/highmap/primitives/coherent_noise.hpp
@@ -794,10 +794,13 @@ Array gavoronoise(const Array  &base,
                   const Array  *p_noise_y = nullptr,
                   glm::vec4     bbox = {0.f, 1.f, 0.f, 1.f});
 
-/*! @brief See hmap::noise. @p period sets the tiling period in lattice cells
- * (typically round(kw)); a non-positive component disables wrapping on that
- * axis (default: non-periodic). Tiling is exact only for lattice noise types
- * with integer kw; simplex is never wrapped. */
+/*! @brief See hmap::noise. @p period sets the tiling period in lattice cells.
+ * For the heightmap to be periodic with respect to the full domain, @p period
+ * must be equal to the wavenumber @p kw, i.e. period = {round(kw.x),
+ * round(kw.y)}; a smaller period makes the pattern repeat within the domain.
+ * A component <= 0 disables wrapping on that axis (default {0, 0}:
+ * non-periodic). Tiling is exact only for lattice noise types with integer
+ * kw; simplex is never wrapped. */
 Array noise(NoiseType     noise_type,
             glm::ivec2    shape,
             glm::vec2     kw,
@@ -806,11 +809,14 @@ Array noise(NoiseType     noise_type,
             const Array  *p_noise_y = nullptr,
             const Array  *p_stretching = nullptr,
             glm::vec4     bbox = {0.f, 1.f, 0.f, 1.f},
-            glm::ivec2    period = {-1, -1});
+            glm::ivec2    period = {0, 0});
 
 /*! @brief See hmap::noise_fbm. @p period sets the tiling period in lattice
- * cells (typically round(kw)); a non-positive component disables wrapping on
- * that axis (default: non-periodic). Seamless tiling additionally requires an
+ * cells for the base octave. For the heightmap to be periodic with respect to
+ * the full domain, @p period must be equal to the wavenumber @p kw, i.e.
+ * period = {round(kw.x), round(kw.y)}; a smaller period makes the pattern
+ * repeat within the domain. A component <= 0 disables wrapping on that axis
+ * (default {0, 0}: non-periodic). Seamless tiling additionally requires an
  * integer lacunarity (the default 2); simplex is never wrapped. */
 Array noise_fbm(NoiseType     noise_type,
                 glm::ivec2    shape,
@@ -825,7 +831,7 @@ Array noise_fbm(NoiseType     noise_type,
                 const Array  *p_noise_y = nullptr,
                 const Array  *p_stretching = nullptr,
                 glm::vec4     bbox = {0.f, 1.f, 0.f, 1.f},
-                glm::ivec2    period = {-1, -1});
+                glm::ivec2    period = {0, 0});
 
 /**
  * @brief Generates a procedural phasor-based pattern.

--- a/HighMap/include/highmap/primitives/coherent_noise.hpp
+++ b/HighMap/include/highmap/primitives/coherent_noise.hpp
@@ -794,7 +794,10 @@ Array gavoronoise(const Array  &base,
                   const Array  *p_noise_y = nullptr,
                   glm::vec4     bbox = {0.f, 1.f, 0.f, 1.f});
 
-/*! @brief See hmap::noise */
+/*! @brief See hmap::noise. @p period sets the tiling period in lattice cells
+ * (typically round(kw)); a non-positive component disables wrapping on that
+ * axis (default: non-periodic). Tiling is exact only for lattice noise types
+ * with integer kw; simplex is never wrapped. */
 Array noise(NoiseType     noise_type,
             glm::ivec2    shape,
             glm::vec2     kw,
@@ -802,9 +805,13 @@ Array noise(NoiseType     noise_type,
             const Array  *p_noise_x = nullptr,
             const Array  *p_noise_y = nullptr,
             const Array  *p_stretching = nullptr,
-            glm::vec4     bbox = {0.f, 1.f, 0.f, 1.f});
+            glm::vec4     bbox = {0.f, 1.f, 0.f, 1.f},
+            glm::ivec2    period = {-1, -1});
 
-/*! @brief See hmap::noise_fbm */
+/*! @brief See hmap::noise_fbm. @p period sets the tiling period in lattice
+ * cells (typically round(kw)); a non-positive component disables wrapping on
+ * that axis (default: non-periodic). Seamless tiling additionally requires an
+ * integer lacunarity (the default 2); simplex is never wrapped. */
 Array noise_fbm(NoiseType     noise_type,
                 glm::ivec2    shape,
                 glm::vec2     kw,
@@ -817,7 +824,8 @@ Array noise_fbm(NoiseType     noise_type,
                 const Array  *p_noise_x = nullptr,
                 const Array  *p_noise_y = nullptr,
                 const Array  *p_stretching = nullptr,
-                glm::vec4     bbox = {0.f, 1.f, 0.f, 1.f});
+                glm::vec4     bbox = {0.f, 1.f, 0.f, 1.f},
+                glm::ivec2    period = {-1, -1});
 
 /**
  * @brief Generates a procedural phasor-based pattern.

--- a/HighMap/src/dbg/dump_visual_check.cpp
+++ b/HighMap/src/dbg/dump_visual_check.cpp
@@ -1,0 +1,56 @@
+/* Copyright (c) 2026 Otto Link. Distributed under the terms of the GNU General
+ * Public License. The full license is in the file LICENSE, distributed with
+ * this software. */
+#include "highmap/array.hpp"
+#include "highmap/export.hpp"
+#include "highmap/gradient.hpp"
+#include "highmap/operator.hpp"
+#include "highmap/range.hpp"
+
+namespace hmap
+{
+
+void dump_visual_check(const Array &array, const std::string &fname)
+{
+  Array out = array;
+  remap(out);
+
+  // C1 continuity
+  {
+    Array gn = gradient_norm(array);
+    remap(gn);
+    out = hstack(out, gn);
+  }
+
+  // C2 continuity
+  {
+    Array dn = abs(laplacian(array));
+    remap(dn);
+    out = hstack(out, dn);
+  }
+
+  // tiling
+  {
+    // line 3 x 1
+    Array a = array;
+    a = hstack(a, array);
+    a = hstack(a, array);
+
+    // stack vertically
+    Array b = a;
+    b = vstack(b, a);
+    b = vstack(b, a);
+
+    // reduce 3 x 3 to initial shape
+    Array bs = b.resample_to_shape(array.shape);
+    out = hstack(out, bs);
+
+    Array gn = gradient_norm(bs);
+    remap(gn);
+    out = hstack(out, gn);
+  }
+
+  out.to_png(fname, hmap::Cmap::JET);
+}
+
+} // namespace hmap

--- a/HighMap/src/dbg/print_array.cpp
+++ b/HighMap/src/dbg/print_array.cpp
@@ -1,3 +1,6 @@
+/* Copyright (c) 2023 Otto Link. Distributed under the terms of the GNU General
+ * Public License. The full license is in the file LICENSE, distributed with
+ * this software. */
 #include <iomanip>
 #include <iostream>
 #include <sstream>

--- a/HighMap/src/gpu_opencl/kernels/noise.cl
+++ b/HighMap/src/gpu_opencl/kernels/noise.cl
@@ -128,9 +128,8 @@ float base_value_cubic(const float2 p, const float fseed, const int2 period)
   float v[4][4];
   for (int dy = -1; dy <= 2; dy++)
     for (int dx = -1; dx <= 2; dx++)
-      v[dy + 1][dx + 1] = hash12f(
-          wrap_lattice(i + (float2)(dx, dy), period),
-          fseed);
+      v[dy + 1][dx + 1] = hash12f(wrap_lattice(i + (float2)(dx, dy), period),
+                                  fseed);
 
   // cubic interpolation in the x-direction for each row
   float interp_row[4];
@@ -177,8 +176,7 @@ float base_worley(const float2 p, const float fseed, const int2 period)
     for (int dy = -1; dy <= 1; dy++)
     {
       float2 dr = (float2)(dx, dy);
-      float2 feature_point = dr +
-                             hash22f(wrap_lattice(i + dr, period), fseed);
+      float2 feature_point = dr + hash22f(wrap_lattice(i + dr, period), fseed);
       float2 diff = f - feature_point;
       float  dist = dot(diff, diff);
 

--- a/HighMap/src/gpu_opencl/kernels/noise.cl
+++ b/HighMap/src/gpu_opencl/kernels/noise.cl
@@ -5,18 +5,38 @@ R""(
 
 // --- BASE NOISE
 
-float base_perlin(const float2 p, const float fseed)
+// Wrap a lattice coordinate modulo a period so the noise tiles seamlessly.
+// A non-positive period component disables wrapping on that axis (default,
+// non-periodic behaviour). Lattice coordinates are integer-valued floats, so
+// the result is exact at the period boundary.
+float2 wrap_lattice(float2 c, const int2 period)
+{
+  if (period.x > 0) c.x = c.x - (float)period.x * floor(c.x / (float)period.x);
+  if (period.y > 0) c.y = c.y - (float)period.y * floor(c.y / (float)period.y);
+  return c;
+}
+
+// Scale a lattice period for the next fbm octave. Tiling stays exact only for
+// integer lacunarity (the default is 2); the round keeps the period integral.
+int2 scale_period(int2 period, const float lacunarity)
+{
+  if (period.x > 0) period.x = (int)(period.x * lacunarity + 0.5f);
+  if (period.y > 0) period.y = (int)(period.y * lacunarity + 0.5f);
+  return period;
+}
+
+float base_perlin(const float2 p, const float fseed, const int2 period)
 {
   // lattice points
   float2 i = floor(p);
   float2 pi;
   float2 f = fract(p, &pi);
 
-  // gradients at lattice corners
-  float2 g00 = grad22f(i + (float2)(0.0f, 0.0f), fseed);
-  float2 g10 = grad22f(i + (float2)(1.0f, 0.0f), fseed);
-  float2 g01 = grad22f(i + (float2)(0.0f, 1.0f), fseed);
-  float2 g11 = grad22f(i + (float2)(1.0f, 1.0f), fseed);
+  // gradients at lattice corners (lattice indices wrapped for tileability)
+  float2 g00 = grad22f(wrap_lattice(i + (float2)(0.0f, 0.0f), period), fseed);
+  float2 g10 = grad22f(wrap_lattice(i + (float2)(1.0f, 0.0f), period), fseed);
+  float2 g01 = grad22f(wrap_lattice(i + (float2)(0.0f, 1.0f), period), fseed);
+  float2 g11 = grad22f(wrap_lattice(i + (float2)(1.0f, 1.0f), period), fseed);
 
   // offset vectors to corners
   float2 d00 = f - (float2)(0.0f, 0.0f);
@@ -78,16 +98,16 @@ float base_simplex2(const float2 p, const float fseed)
   return 100.f * (n0 + n1 + n2);
 }
 
-float base_value(const float2 p, const float fseed)
+float base_value(const float2 p, const float fseed, const int2 period)
 {
   float2 i = floor(p);
   float2 pi;
   float2 f = fract(p, &pi);
 
-  float v00 = hash12f(i + (float2)(0.0f, 0.0f), fseed);
-  float v10 = hash12f(i + (float2)(1.0f, 0.0f), fseed);
-  float v01 = hash12f(i + (float2)(0.0f, 1.0f), fseed);
-  float v11 = hash12f(i + (float2)(1.0f, 1.0f), fseed);
+  float v00 = hash12f(wrap_lattice(i + (float2)(0.0f, 0.0f), period), fseed);
+  float v10 = hash12f(wrap_lattice(i + (float2)(1.0f, 0.0f), period), fseed);
+  float v01 = hash12f(wrap_lattice(i + (float2)(0.0f, 1.0f), period), fseed);
+  float v11 = hash12f(wrap_lattice(i + (float2)(1.0f, 1.0f), period), fseed);
 
   float2 u = smoothstep3_f2(f);
 
@@ -98,7 +118,7 @@ float base_value(const float2 p, const float fseed)
   return 2.f * nxy - 1.f;
 }
 
-float base_value_cubic(const float2 p, const float fseed)
+float base_value_cubic(const float2 p, const float fseed, const int2 period)
 {
   float2 i = floor(p);
   float2 pi;
@@ -108,7 +128,9 @@ float base_value_cubic(const float2 p, const float fseed)
   float v[4][4];
   for (int dy = -1; dy <= 2; dy++)
     for (int dx = -1; dx <= 2; dx++)
-      v[dy + 1][dx + 1] = hash12f(i + (float2)(dx, dy), fseed);
+      v[dy + 1][dx + 1] = hash12f(
+          wrap_lattice(i + (float2)(dx, dy), period),
+          fseed);
 
   // cubic interpolation in the x-direction for each row
   float interp_row[4];
@@ -125,16 +147,16 @@ float base_value_cubic(const float2 p, const float fseed)
   return 1.43f * (value - 0.5f);
 }
 
-float base_value_linear(const float2 p, const float fseed)
+float base_value_linear(const float2 p, const float fseed, const int2 period)
 {
   float2 i = floor(p);
   float2 pi;
   float2 f = fract(p, &pi);
 
-  float v00 = hash12f(i + (float2)(0.0f, 0.0f), fseed);
-  float v10 = hash12f(i + (float2)(1.0f, 0.0f), fseed);
-  float v01 = hash12f(i + (float2)(0.0f, 1.0f), fseed);
-  float v11 = hash12f(i + (float2)(1.0f, 1.0f), fseed);
+  float v00 = hash12f(wrap_lattice(i + (float2)(0.0f, 0.0f), period), fseed);
+  float v10 = hash12f(wrap_lattice(i + (float2)(1.0f, 0.0f), period), fseed);
+  float v01 = hash12f(wrap_lattice(i + (float2)(0.0f, 1.0f), period), fseed);
+  float v11 = hash12f(wrap_lattice(i + (float2)(1.0f, 1.0f), period), fseed);
 
   float nx0 = lerp(v00, v10, f.x);
   float nx1 = lerp(v01, v11, f.x);
@@ -143,7 +165,7 @@ float base_value_linear(const float2 p, const float fseed)
   return 2.f * nxy - 1.f;
 }
 
-float base_worley(const float2 p, const float fseed)
+float base_worley(const float2 p, const float fseed, const int2 period)
 {
   float2 i = floor(p);
   float2 pi;
@@ -155,7 +177,8 @@ float base_worley(const float2 p, const float fseed)
     for (int dy = -1; dy <= 1; dy++)
     {
       float2 dr = (float2)(dx, dy);
-      float2 feature_point = dr + hash22f(i + dr, fseed);
+      float2 feature_point = dr +
+                             hash22f(wrap_lattice(i + dr, period), fseed);
       float2 diff = f - feature_point;
       float  dist = dot(diff, diff);
 
@@ -173,18 +196,21 @@ float base_perlin_fbm(const float2 p,
                       const float  weight,
                       const float  persistence,
                       const float  lacunarity,
-                      const float  fseed)
+                      const float  fseed,
+                      const int2   period)
 {
   float n = 0.f;
   float nf = 1.f;
   float na = 0.6f;
+  int2  per = period;
   for (int i = 0; i < octaves; i++)
   {
-    float v = base_perlin(p * nf, fseed);
+    float v = base_perlin(p * nf, fseed, per);
     n += v * na;
     na *= (1.f - weight) + weight * min(v + 1.f, 2.f) * 0.5f;
     na *= persistence;
     nf *= lacunarity;
+    per = scale_period(per, lacunarity);
   }
   return n;
 }
@@ -194,18 +220,21 @@ float base_perlin_billow_fbm(const float2 p,
                              const float  weight,
                              const float  persistence,
                              const float  lacunarity,
-                             const float  fseed)
+                             const float  fseed,
+                             const int2   period)
 {
   float n = 0.f;
   float nf = 1.f;
   float na = 0.6f;
+  int2  per = period;
   for (int i = 0; i < octaves; i++)
   {
-    float v = 2.f * fabs(base_perlin(p * nf, fseed)) - 1.f;
+    float v = 2.f * fabs(base_perlin(p * nf, fseed, per)) - 1.f;
     n += v * na;
     na *= (1.f - weight) + weight * min(v + 1.f, 2.f) * 0.5f;
     na *= persistence;
     nf *= lacunarity;
+    per = scale_period(per, lacunarity);
   }
   return n;
 }
@@ -215,18 +244,21 @@ float base_perlin_half_fbm(const float2 p,
                            const float  weight,
                            const float  persistence,
                            const float  lacunarity,
-                           const float  fseed)
+                           const float  fseed,
+                           const int2   period)
 {
   float n = 0.f;
   float nf = 1.f;
   float na = 0.6f;
+  int2  per = period;
   for (int i = 0; i < octaves; i++)
   {
-    float v = max_smooth(base_perlin(p * nf, fseed), 0.f, 0.5f);
+    float v = max_smooth(base_perlin(p * nf, fseed, per), 0.f, 0.5f);
     n += v * na;
     na *= (1.f - weight) + weight * min(v + 1.f, 2.f) * 0.5f;
     na *= persistence;
     nf *= lacunarity;
+    per = scale_period(per, lacunarity);
   }
   return n;
 }
@@ -257,18 +289,21 @@ float base_value_fbm(const float2 p,
                      const float  weight,
                      const float  persistence,
                      const float  lacunarity,
-                     const float  fseed)
+                     const float  fseed,
+                     const int2   period)
 {
   float n = 0.f;
   float nf = 1.f;
   float na = 0.6f;
+  int2  per = period;
   for (int i = 0; i < octaves; i++)
   {
-    float v = base_value(p * nf, fseed);
+    float v = base_value(p * nf, fseed, per);
     n += v * na;
     na *= (1.f - weight) + weight * min(v + 1.f, 2.f) * 0.5f;
     na *= persistence;
     nf *= lacunarity;
+    per = scale_period(per, lacunarity);
   }
   return n;
 }
@@ -278,18 +313,21 @@ float base_value_cubic_fbm(const float2 p,
                            const float  weight,
                            const float  persistence,
                            const float  lacunarity,
-                           const float  fseed)
+                           const float  fseed,
+                           const int2   period)
 {
   float n = 0.f;
   float nf = 1.f;
   float na = 0.6f;
+  int2  per = period;
   for (int i = 0; i < octaves; i++)
   {
-    float v = base_value_cubic(p * nf, fseed);
+    float v = base_value_cubic(p * nf, fseed, per);
     n += v * na;
     na *= (1.f - weight) + weight * min(v + 1.f, 2.f) * 0.5f;
     na *= persistence;
     nf *= lacunarity;
+    per = scale_period(per, lacunarity);
   }
   return n;
 }
@@ -299,18 +337,21 @@ float base_value_linear_fbm(const float2 p,
                             const float  weight,
                             const float  persistence,
                             const float  lacunarity,
-                            const float  fseed)
+                            const float  fseed,
+                            const int2   period)
 {
   float n = 0.f;
   float nf = 1.f;
   float na = 0.6f;
+  int2  per = period;
   for (int i = 0; i < octaves; i++)
   {
-    float v = base_value_linear(p * nf, fseed);
+    float v = base_value_linear(p * nf, fseed, per);
     n += v * na;
     na *= (1.f - weight) + weight * min(v + 1.f, 2.f) * 0.5f;
     na *= persistence;
     nf *= lacunarity;
+    per = scale_period(per, lacunarity);
   }
   return n;
 }
@@ -320,18 +361,21 @@ float base_worley_fbm(const float2 p,
                       const float  weight,
                       const float  persistence,
                       const float  lacunarity,
-                      const float  fseed)
+                      const float  fseed,
+                      const int2   period)
 {
   float n = 0.f;
   float nf = 1.f;
   float na = 0.6f;
+  int2  per = period;
   for (int i = 0; i < octaves; i++)
   {
-    float v = base_worley(p * nf, fseed);
+    float v = base_worley(p * nf, fseed, per);
     n += v * na;
     na *= (1.f - weight) + weight * min(v + 1.f, 2.f) * 0.5f;
     na *= persistence;
     nf *= lacunarity;
+    per = scale_period(per, lacunarity);
   }
   return n;
 }
@@ -349,6 +393,8 @@ void kernel noise(global float *output,
                   const uint    seed,
                   const int     has_noise_x,
                   const int     has_noise_y,
+                  const int     period_x,
+                  const int     period_y,
                   const float4  bbox)
 {
   int2 g = {get_global_id(0), get_global_id(1)};
@@ -363,20 +409,22 @@ void kernel noise(global float *output,
   float dx = has_noise_x > 0 ? noise_x[index] : 0.f;
   float dy = has_noise_y > 0 ? noise_y[index] : 0.f;
 
+  int2 period = {period_x, period_y};
+
   float2 pos = g_to_xy(g, nx, ny, kx, ky, dx, dy, bbox);
 
   if (noise_id == 1)
   {
-    output[index] = base_perlin(pos, fseed);
+    output[index] = base_perlin(pos, fseed, period);
   }
   else if (noise_id == 2)
   {
-    float value = base_perlin(pos, fseed);
+    float value = base_perlin(pos, fseed, period);
     output[index] = 2.f * fabs(value) - 1.f;
   }
   else if (noise_id == 3)
   {
-    float value = base_perlin(pos, fseed);
+    float value = base_perlin(pos, fseed, period);
     output[index] = max_smooth(value, 0.f, 0.5f);
   }
   else if (noise_id == 4)
@@ -385,19 +433,19 @@ void kernel noise(global float *output,
   }
   else if (noise_id == 6)
   {
-    output[index] = base_value(pos, fseed);
+    output[index] = base_value(pos, fseed, period);
   }
   else if (noise_id == 7)
   {
-    output[index] = base_value_cubic(pos, fseed);
+    output[index] = base_value_cubic(pos, fseed, period);
   }
   else if (noise_id == 9)
   {
-    output[index] = base_value_linear(pos, fseed);
+    output[index] = base_value_linear(pos, fseed, period);
   }
   else if (noise_id == 10)
   {
-    output[index] = base_worley(pos, fseed);
+    output[index] = base_worley(pos, fseed, period);
   }
   else
   {
@@ -422,6 +470,8 @@ void kernel noise_fbm(global float *output,
                       const int     has_ctrl_param,
                       const int     has_noise_x,
                       const int     has_noise_y,
+                      const int     period_x,
+                      const int     period_y,
                       const float4  bbox)
 {
   int2 g = {get_global_id(0), get_global_id(1)};
@@ -437,6 +487,8 @@ void kernel noise_fbm(global float *output,
   float dx = has_noise_x > 0 ? noise_x[index] : 0.f;
   float dy = has_noise_y > 0 ? noise_y[index] : 0.f;
 
+  int2 period = {period_x, period_y};
+
   float  new_weight = (1.f - ct) + ct * weight;
   float2 pos = g_to_xy(g, nx, ny, kx, ky, dx, dy, bbox);
 
@@ -447,7 +499,8 @@ void kernel noise_fbm(global float *output,
                                     new_weight,
                                     persistence,
                                     lacunarity,
-                                    fseed);
+                                    fseed,
+                                    period);
   }
   else if (noise_id == 2)
   {
@@ -456,7 +509,8 @@ void kernel noise_fbm(global float *output,
                                            new_weight,
                                            persistence,
                                            lacunarity,
-                                           fseed);
+                                           fseed,
+                                           period);
   }
   else if (noise_id == 3)
   {
@@ -465,7 +519,8 @@ void kernel noise_fbm(global float *output,
                                          new_weight,
                                          persistence,
                                          lacunarity,
-                                         fseed);
+                                         fseed,
+                                         period);
   }
   else if (noise_id == 4)
   {
@@ -483,7 +538,8 @@ void kernel noise_fbm(global float *output,
                                    new_weight,
                                    persistence,
                                    lacunarity,
-                                   fseed);
+                                   fseed,
+                                   period);
   }
   else if (noise_id == 7)
   {
@@ -492,7 +548,8 @@ void kernel noise_fbm(global float *output,
                                          new_weight,
                                          persistence,
                                          lacunarity,
-                                         fseed);
+                                         fseed,
+                                         period);
   }
   else if (noise_id == 9)
   {
@@ -501,7 +558,8 @@ void kernel noise_fbm(global float *output,
                                           new_weight,
                                           persistence,
                                           lacunarity,
-                                          fseed);
+                                          fseed,
+                                          period);
   }
   else if (noise_id == 10)
   {
@@ -510,7 +568,8 @@ void kernel noise_fbm(global float *output,
                                     new_weight,
                                     persistence,
                                     lacunarity,
-                                    fseed);
+                                    fseed,
+                                    period);
   }
   else
   {

--- a/HighMap/src/gpu_opencl/kernels/strata.cl
+++ b/HighMap/src/gpu_opencl/kernels/strata.cl
@@ -90,7 +90,13 @@ void kernel strata(global float *output,
   float shift = slope * dr;
 
   // TODO hardcoded
-  float noise = base_perlin_fbm(noise_kw * pos, 6, 1.f, 0.99f, 2.f, fseed);
+  float noise = base_perlin_fbm(noise_kw * pos,
+                                6,
+                                1.f,
+                                0.99f,
+                                2.f,
+                                fseed,
+                                (int2)(0, 0)); // non-periodic
 
   // ridges
   float  dr_p = dot(pos, (float2)(cos(alpha_ridge), sin(alpha_ridge)));

--- a/HighMap/src/primitives/coherent_noise/primitives_gpu.cpp
+++ b/HighMap/src/primitives/coherent_noise/primitives_gpu.cpp
@@ -508,7 +508,8 @@ Array noise(NoiseType     noise_type,
             const Array  *p_noise_x,
             const Array  *p_noise_y,
             const Array * /* p_stretching */,
-            glm::vec4 bbox)
+            glm::vec4  bbox,
+            glm::ivec2 period)
 {
   Array array(shape);
 
@@ -528,6 +529,8 @@ Array noise(NoiseType     noise_type,
                      seed,
                      p_noise_x ? 1 : 0,
                      p_noise_y ? 1 : 0,
+                     period.x,
+                     period.y,
                      bbox);
 
   run.write_buffer("array");
@@ -549,7 +552,8 @@ Array noise_fbm(NoiseType     noise_type,
                 const Array  *p_noise_x,
                 const Array  *p_noise_y,
                 const Array * /* p_stretching */,
-                glm::vec4 bbox)
+                glm::vec4  bbox,
+                glm::ivec2 period)
 {
   Array array(shape);
 
@@ -575,6 +579,8 @@ Array noise_fbm(NoiseType     noise_type,
                      p_ctrl_param ? 1 : 0,
                      p_noise_x ? 1 : 0,
                      p_noise_y ? 1 : 0,
+                     period.x,
+                     period.y,
                      bbox);
 
   run.write_buffer("array");


### PR DESCRIPTION
Adds an opt-in periodic mode so `gpu::noise` and `gpu::noise_fbm` can tile seamlessly.

## Approach
The GPU noise is a custom integer-lattice implementation (not FastNoiseLite), so tiling is done by **lattice-coordinate wrapping** rather than 4D-torus sampling: the `base_*` lattice functions wrap their corner indices modulo a `period` before the gradient/hash lookup, and the fbm wrappers scale the period by `lacunarity` each octave. `pos` already encodes global domain coords via `bbox`, so the wrap is consistent across tiled regions.

Exposed as `glm::ivec2 period` (default `{0,0}` = non-periodic; set `period = round(kw)` for tiling across the full domain) on `hmap::gpu::noise` / `noise_fbm`, placed **after `bbox`** so existing positional callers are unaffected (host `bind_arguments` still passes it before `bbox` to match the kernel).

## Constraints (inherent to lattice tiling)
- Well-defined for lattice noise: perlin / value / value_cubic / value_linear / worley.
- Requires integer `kw` (period = round(kw) cells) and integer `lacunarity` (default 2) for seamless fbm.
- **Simplex** uses a skewed lattice and is intentionally left unwrapped (periodic is a no-op for it).

CPU (FastNoiseLite) path is intentionally left unchanged.

## Notes
- `strata.cl` (the one other in-kernel caller of `base_perlin_fbm`) updated to pass a non-periodic `period`.
- Runtime-verified: OpenCL program builds on an NVIDIA device and the toggle tiles.
