### PR TITLE
fix(interpolate): guard array interpolation against an empty source

### DIFF
--- a/HighMap/src/interpolate/interpolate_array.cpp
+++ b/HighMap/src/interpolate/interpolate_array.cpp
@@ -5,6 +5,8 @@
 #include <cmath>
 #include <vector>
 
+#include "macrologger.h"
+
 #include "highmap/array.hpp"
 #include "highmap/interpolate/interpolate2d.hpp"
 #include "highmap/interpolate/interpolate_array.hpp"
@@ -12,6 +14,30 @@
 
 namespace hmap
 {
+
+namespace
+{
+
+// Interpolating from an empty source has no defined result, and the index
+// arithmetic in these routines is undefined for a zero dimension:
+// std::clamp(v, 0, shape.x - 1) becomes std::clamp(v, 0, -1), whose contract is
+// violated when lo > hi and which in practice returns -1, indexing before the
+// buffer. 1 / shape.x is also inf. Leave the target as-is — it is zero-filled
+// by its constructor, which is the only sensible result here.
+bool empty_source(const Array &source, const char *caller)
+{
+  if (source.shape.x < 1 || source.shape.y < 1)
+  {
+    LOG_DEBUG("%s: empty source (%dx%d), leaving target unchanged",
+              caller,
+              source.shape.x,
+              source.shape.y);
+    return true;
+  }
+  return false;
+}
+
+} // namespace
 
 void interpolate_array_bicubic(const Array &source,
                                Array       &target,
@@ -36,6 +62,8 @@ void interpolate_array_bicubic(const Array     &source,
                                bool             endpoint,
                                bool             pixel_centered)
 {
+  if (empty_source(source, "interpolate_array_bicubic")) return;
+
   float dx_s = 1.f / static_cast<float>(source.shape.x);
   float dy_s = 1.f / static_cast<float>(source.shape.y);
 
@@ -127,6 +155,8 @@ void interpolate_array_bilinear(const Array     &source,
                                 bool             endpoint,
                                 bool             pixel_centered)
 {
+  if (empty_source(source, "interpolate_array_bilinear")) return;
+
   float dx_s = 1.f / static_cast<float>(source.shape.x);
   float dy_s = 1.f / static_cast<float>(source.shape.y);
 
@@ -201,6 +231,8 @@ void interpolate_array_nearest(const Array     &source,
                                const glm::vec4 &bbox_target,
                                bool             endpoint)
 {
+  if (empty_source(source, "interpolate_array_nearest")) return;
+
   std::vector<float> x = linspace(bbox_target.x,
                                   bbox_target.y,
                                   target.shape.x,

--- a/HighMap/src/interpolate/interpolate_array_gpu.cpp
+++ b/HighMap/src/interpolate/interpolate_array_gpu.cpp
@@ -3,12 +3,35 @@
  * this software. */
 #include <vector>
 
+#include "macrologger.h"
+
 #include "cl_wrapper/run.hpp"
 
 #include "highmap/array.hpp"
 
 namespace hmap::gpu
 {
+
+namespace
+{
+
+// A zero-sized source cannot be bound as an OpenCL image, and interpolating
+// from an empty array has no defined result. Leave the target as-is (its
+// constructor zero-fills it). Mirrors the CPU guard in interpolate_array.cpp.
+bool empty_source(const Array &source, const char *caller)
+{
+  if (source.shape.x < 1 || source.shape.y < 1)
+  {
+    LOG_DEBUG("%s: empty source (%dx%d), leaving target unchanged",
+              caller,
+              source.shape.x,
+              source.shape.y);
+    return true;
+  }
+  return false;
+}
+
+} // namespace
 
 // helpers
 
@@ -37,6 +60,8 @@ glm::vec4 helper_transform_bbox(const glm::vec4 &bbox_source,
 
 void interpolate_array_bicubic(const Array &source, Array &target)
 {
+  if (empty_source(source, "interpolate_array_bicubic")) return;
+
   glm::vec4 bbox(0.f, 1.f, 0.f, 1.f);
 
   auto run = clwrapper::Run("interpolate_array_bicubic");
@@ -64,6 +89,8 @@ void interpolate_array_bicubic(const Array     &source,
                                const glm::vec4 &bbox_source,
                                const glm::vec4 &bbox_target)
 {
+  if (empty_source(source, "interpolate_array_bicubic")) return;
+
   glm::vec4 bbox_target_mod = helper_transform_bbox(bbox_source, bbox_target);
 
   // compute
@@ -89,6 +116,8 @@ void interpolate_array_bicubic(const Array     &source,
 
 void interpolate_array_bilinear(const Array &source, Array &target)
 {
+  if (empty_source(source, "interpolate_array_bilinear")) return;
+
   glm::vec4 bbox(0.f, 1.f, 0.f, 1.f);
 
   auto run = clwrapper::Run("interpolate_array_bilinear");
@@ -112,6 +141,8 @@ void interpolate_array_bilinear(const Array     &source,
                                 const glm::vec4 &bbox_source,
                                 const glm::vec4 &bbox_target)
 {
+  if (empty_source(source, "interpolate_array_bilinear")) return;
+
   glm::vec4 bbox_target_mod = helper_transform_bbox(bbox_source, bbox_target);
 
   // compute
@@ -133,6 +164,8 @@ void interpolate_array_bilinear(const Array     &source,
 
 void interpolate_array_lagrange(const Array &source, Array &target, int order)
 {
+  if (empty_source(source, "interpolate_array_lagrange")) return;
+
   auto run = clwrapper::Run("interpolate_array_lagrange");
 
   run.bind_imagef("source", source.vector, source.shape.x, source.shape.y);
@@ -155,6 +188,8 @@ void interpolate_array_lagrange(const Array &source, Array &target, int order)
 
 void interpolate_array_nearest(const Array &source, Array &target)
 {
+  if (empty_source(source, "interpolate_array_nearest")) return;
+
   glm::vec4 bbox(0.f, 1.f, 0.f, 1.f);
 
   auto run = clwrapper::Run("interpolate_array_nearest");
@@ -178,6 +213,8 @@ void interpolate_array_nearest(const Array     &source,
                                const glm::vec4 &bbox_source,
                                const glm::vec4 &bbox_target)
 {
+  if (empty_source(source, "interpolate_array_nearest")) return;
+
   glm::vec4 bbox_target_mod = helper_transform_bbox(bbox_source, bbox_target);
 
   // compute

--- a/tests/src/test_interpolate_array_empty_source.cpp
+++ b/tests/src/test_interpolate_array_empty_source.cpp
@@ -1,0 +1,102 @@
+#include "highmap.hpp"
+
+#include <gtest/gtest.h>
+
+// Interpolating from a zero-sized source used to be undefined behaviour: the
+// index arithmetic reduces to std::clamp(v, 0, shape.x - 1) == std::clamp(v, 0,
+// -1), whose precondition (lo <= hi) is violated and which in practice yields
+// -1, so source(-1, -1) reads before the buffer and segfaults.
+//
+// Reached from Hesiod by opening any project whose Brush node deserialized to an
+// empty array (otto-link/Hesiod#658): Array::resample_to_shape_bilinear on a 0x0
+// source. An empty source has no meaningful interpolation, so the contract is to
+// leave the target at its zero-filled initial state.
+
+namespace
+{
+
+void expect_all_zero(const hmap::Array &z)
+{
+  for (int j = 0; j < z.shape.y; ++j)
+    for (int i = 0; i < z.shape.x; ++i)
+      EXPECT_EQ(z(i, j), 0.f);
+}
+
+} // namespace
+
+TEST(InterpolateArrayEmptySource, BilinearLeavesTargetZeroed)
+{
+  hmap::Array source; // default-constructed: 0x0
+  hmap::Array target(glm::ivec2(16, 16));
+
+  ASSERT_EQ(source.shape.x, 0);
+  ASSERT_EQ(source.shape.y, 0);
+
+  hmap::interpolate_array_bilinear(source, target);
+
+  EXPECT_EQ(target.shape.x, 16);
+  EXPECT_EQ(target.shape.y, 16);
+  expect_all_zero(target);
+}
+
+TEST(InterpolateArrayEmptySource, NearestLeavesTargetZeroed)
+{
+  hmap::Array source;
+  hmap::Array target(glm::ivec2(16, 16));
+
+  hmap::interpolate_array_nearest(source, target);
+
+  expect_all_zero(target);
+}
+
+TEST(InterpolateArrayEmptySource, BicubicLeavesTargetZeroed)
+{
+  hmap::Array source;
+  hmap::Array target(glm::ivec2(16, 16));
+
+  hmap::interpolate_array_bicubic(source, target);
+
+  expect_all_zero(target);
+}
+
+TEST(InterpolateArrayEmptySource, SingleDegenerateDimensionIsHandled)
+{
+  // only one dimension collapsed — still degenerate for the index arithmetic
+  hmap::Array source(glm::ivec2(0, 8));
+  hmap::Array target(glm::ivec2(16, 16));
+
+  hmap::interpolate_array_bilinear(source, target);
+
+  expect_all_zero(target);
+}
+
+TEST(InterpolateArrayEmptySource, ResampleToShapeIsSafe)
+{
+  // the path Hesiod's Brush node actually took
+  hmap::Array source;
+
+  hmap::Array out_bilinear = source.resample_to_shape_bilinear(glm::ivec2(32, 32));
+  EXPECT_EQ(out_bilinear.shape.x, 32);
+  EXPECT_EQ(out_bilinear.shape.y, 32);
+  expect_all_zero(out_bilinear);
+
+  hmap::Array out_nearest = source.resample_to_shape_nearest(glm::ivec2(32, 32));
+  EXPECT_EQ(out_nearest.shape.x, 32);
+  EXPECT_EQ(out_nearest.shape.y, 32);
+  expect_all_zero(out_nearest);
+}
+
+TEST(InterpolateArrayEmptySource, NonEmptySourceStillInterpolates)
+{
+  // guard must not short-circuit the normal path
+  hmap::Array source(glm::ivec2(2, 2));
+  source(0, 0) = 0.f;
+  source(1, 0) = 1.f;
+  source(0, 1) = 1.f;
+  source(1, 1) = 2.f;
+
+  hmap::Array target(glm::ivec2(8, 8));
+  hmap::interpolate_array_bilinear(source, target);
+
+  EXPECT_GT(target.max(), 0.f);
+}


### PR DESCRIPTION
The index arithmetic in the array interpolators is undefined for a zero-sized source:

```cpp
is0 = std::clamp(is0, 0, source.shape.x - 1);   // shape.x == 0  ->  std::clamp(is0, 0, -1)
```

`std::clamp` requires `lo <= hi`; with `hi == -1` the contract is violated, and in practice it returns `hi`. `source(-1, -1)` then reads 4 bytes before the buffer and segfaults. On the same path `1.f / shape.x` is `inf`, so the coordinates are already meaningless before any indexing happens.

Present in all three CPU interpolators (`bicubic:92-93`, `bilinear:169-177`, `nearest:224-225`) and, as the same missing precondition, in the seven GPU wrappers — a 0×0 source cannot be bound as an OpenCL image.

An empty source has no meaningful interpolation, so this leaves the target at its zero-filled initial state and logs at debug level, matching the existing empty-input handling in `interpolate_heightmap_virtual_array.cpp:67`.

### How it was found

Opening a Hesiod project whose `Brush` node deserialized to an empty array (otto-link/Hesiod#658) — `Array::resample_to_shape_bilinear` on a 0×0 source. From the core dump:

```
rdi = 0x00000000ffffffff        (-1)
cr2 = 0xfffffffffffffffc        (-4)
hmap::interpolate_array_bilinear()
hmap::Array::resample_to_shape_bilinear()
hesiod::compute_brush_node()
```

That particular route is fixed on the Hesiod side, but the precondition was missing for every caller, so the landmine stays armed without this.

### Testing

New `tests/src/test_interpolate_array_empty_source.cpp` covers all three interpolators, a singly-degenerate shape (`0×8`), both `resample_to_shape_*` entry points, and a non-empty case asserting the guard doesn't short-circuit normal interpolation.

Verified the tests discriminate rather than merely pass:

- guards reverted → `SIGSEGV` (exit 139) on the first case
- guards applied → 6/6 pass
- full suite → **297/297 pass** (53 suites)

GPU wrappers are guarded by symmetry but not covered by the new tests, which are CPU-only.

### Note

This is my second open PR here — #400 (MSVC Release `/Od`) is still awaiting review. They're independent and touch different files, so they can land in either order.
